### PR TITLE
Fix exports path

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "module": "dist/index.es.js",
   "exports": {
     ".": {
-      "import": "dist/index.es.js",
-      "types": "dist/index.d.ts"
+      "import": "./dist/index.es.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
The warning is causing a problem about type referencing.

![ss001](https://github.com/akiomik/vitest-websocket-mock/assets/24215933/e63269b0-a5a7-4e80-8c6a-5ea805c236ff)

In my project, source code put at `src/*.ts` can refer type properly, but for instance `src/foo/*.ts` cannot.