### PR TITLE
Remove typing workaround

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -30,7 +30,7 @@ declare module 'vitest' {
 }
 
 const WAIT_DELAY = 1000;
-const TIMEOUT = Symbol('timoeut');
+const TIMEOUT = Symbol('timeout');
 
 const makeInvalidWsMessage = function makeInvalidWsMessage(this: MatcherState, ws: WS, matcher: string) {
   return (

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -15,14 +15,6 @@ interface WSOptions extends ServerOptions {
 }
 export type DeserializedMessage<TMessage = object> = string | TMessage;
 
-// The WebSocket object passed to the `connection` callback is actually
-// a WebSocket proxy that overrides the signature of the `close` method.
-// To work around this inconsistency, we need to override the WebSocket
-// interface. See https://github.com/romgain/jest-websocket-mock/issues/26#issuecomment-571579567
-interface MockWebSocket extends Omit<Client, 'close'> {
-  close(options?: CloseOptions): void;
-}
-
 export default class WS {
   server: Server;
   serializer: (deserializedMessage: DeserializedMessage) => string;
@@ -101,7 +93,7 @@ export default class WS {
     return this.messagesToConsume.get();
   }
 
-  on(eventName: 'connection' | 'message' | 'close', callback: (socket: MockWebSocket) => void): void {
+  on(eventName: 'connection' | 'message' | 'close', callback: (socket: Client) => void): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore https://github.com/romgain/jest-websocket-mock/issues/26#issuecomment-571579567
     this.server.on(eventName, callback);

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -94,8 +94,6 @@ export default class WS {
   }
 
   on(eventName: 'connection' | 'message' | 'close', callback: (socket: Client) => void): void {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore https://github.com/romgain/jest-websocket-mock/issues/26#issuecomment-571579567
     this.server.on(eventName, callback);
   }
 


### PR DESCRIPTION
The issue commented here has been resolved, so we can use the original `Client` type here.