### PR TITLE
Add custom matcher factory

### DIFF
--- a/src/__tests__/matchers.test.ts
+++ b/src/__tests__/matchers.test.ts
@@ -8,6 +8,7 @@ import '../matchers';
 import chalk from 'chalk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { deriveToHaveReceivedMessage, deriveToReceiveMessage } from '../matchers';
 import WS from '../websocket';
 
 let server: WS, client: WebSocket;
@@ -274,5 +275,109 @@ Expected the websocket object to be a valid WS mock.
 Received: string
   [31m\\"boom\\"[39m"
 `);
+  });
+});
+
+describe('A custom matcher `toReceiveHello` derived from toReceiveMessage', () => {
+  expect.extend({
+    toReceiveHello: deriveToReceiveMessage('toReceiveHello', function (received) {
+      const pass = received === 'Hello';
+      const message = pass
+        ? () => `Expected the next received message is not Hello, but got ${received}`
+        : () => `Expected the next received message is Hello, but got ${received}`;
+
+      return {
+        actual: received,
+        expected: 'Hello',
+        message,
+        pass,
+      };
+    }),
+  });
+
+  it('passes when received "Hello"', async () => {
+    client.send('Hello');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (expect(server) as any).toReceiveHello();
+  });
+
+  it('fails when received "Hi!"', async () => {
+    client.send('Hi!');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect((expect(server) as any).toReceiveHello()).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Expected the next received message is Hello, but got Hi!"'
+    );
+  });
+
+  it('fails when received "Hello" under .not context', async () => {
+    client.send('Hello');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect((expect(server) as any).not.toReceiveHello()).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Expected the next received message is not Hello, but got Hello"'
+    );
+  });
+
+  it('passes when received "Hi!" under .not context', async () => {
+    client.send('Hi!');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (expect(server) as any).not.toReceiveHello();
+  });
+});
+
+describe('A custom matcher `toHaveHello` derived from toHaveReceivedMessages', () => {
+  expect.extend({
+    toHaveHello: deriveToHaveReceivedMessage('toHaveHello', function (received) {
+      const pass = received.includes('Hello');
+      const message = pass
+        ? () => `Expected the WS server to not have received Hello, but got ${received}`
+        : () => `Expected the WS server to have received Hello, but got ${received}`;
+
+      return {
+        actual: received,
+        expected: ['Hello'],
+        message,
+        pass,
+      };
+    }),
+  });
+
+  it('passes when received "Hello"', async () => {
+    client.send('Hi!');
+    client.send('Hello');
+    await server.nextMessage;
+    await server.nextMessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (expect(server) as any).toHaveHello();
+  });
+
+  it('fails when not received "Hello"', async () => {
+    client.send('Hi!');
+    client.send('Yo');
+    await server.nextMessage;
+    await server.nextMessage;
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (expect(server) as any).toHaveHello();
+    }).toThrowErrorMatchingInlineSnapshot('"Expected the WS server to have received Hello, but got Hi!,Yo"');
+  });
+
+  it('fails when received "Hello" under .not context', async () => {
+    client.send('Hi!');
+    client.send('Hello');
+    await server.nextMessage;
+    await server.nextMessage;
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (expect(server) as any).not.toHaveHello();
+    }).toThrowErrorMatchingInlineSnapshot('"Expected the WS server to not have received Hello, but got Hi!,Hello"');
+  });
+
+  it('passes when not received "Hello" under .not context', async () => {
+    client.send('Hi!');
+    client.send('Yo');
+    await server.nextMessage;
+    await server.nextMessage;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (expect(server) as any).not.toHaveHello();
   });
 });

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -3,14 +3,12 @@
  * @copyright Akiomi Kamakura 2023
  */
 
+import type { MatcherState, RawMatcherFn } from '@vitest/expect';
 import { diff } from 'jest-diff';
-import type { ExpectStatic } from 'vitest';
 import { expect } from 'vitest';
 
 import WS from './websocket';
 import { DeserializedMessage } from './websocket';
-
-export type MatcherState = ReturnType<ExpectStatic['getState']>;
 
 export type ReceiveMessageOptions = {
   timeout?: number;
@@ -42,13 +40,13 @@ const makeInvalidWsMessage = function makeInvalidWsMessage(this: MatcherState, w
   );
 };
 
-expect.extend({
-  async toReceiveMessage(ws: WS, expected: DeserializedMessage, options?: ReceiveMessageOptions) {
+export const deriveToReceiveMessage = (name: string, fn: RawMatcherFn): RawMatcherFn => {
+  return async function (ws: WS, expected: DeserializedMessage, options?: ReceiveMessageOptions) {
     const isWS = ws instanceof WS;
     if (!isWS) {
       return {
         pass: this.isNot, // always fail
-        message: makeInvalidWsMessage.bind(this, ws, 'toReceiveMessage'),
+        message: makeInvalidWsMessage.bind(this, ws, name),
       };
     }
 
@@ -63,34 +61,92 @@ expect.extend({
       return {
         pass: this.isNot, // always fail
         message: () =>
-          this.utils.matcherHint(this.isNot ? '.not.toReceiveMessage' : '.toReceiveMessage', 'WS', 'expected') +
+          this.utils.matcherHint(`${this.isNot ? '.not' : ''}.${name}`, 'WS', 'expected') +
           '\n\n' +
           `Expected the websocket server to receive a message,\n` +
           `but it didn't receive anything in ${waitDelay}ms.`,
       };
-    }
-    const received = messageOrTimeout;
+    } else {
+      const received = messageOrTimeout;
+      const result = await Promise.resolve(fn.bind(this)(received, expected, options));
 
-    const pass = this.equals(received, expected);
+      return { name, ...result };
+    }
+  };
+};
+
+const toReceiveMessage = deriveToReceiveMessage('toReceiveMessage', function (received, expected) {
+  const pass = this.equals(received, expected);
+
+  const message = pass
+    ? () =>
+        this.utils.matcherHint('.not.toReceiveMessage', 'WS', 'expected') +
+        '\n\n' +
+        `Expected the next received message to not equal:\n` +
+        `  ${this.utils.printExpected(expected)}\n` +
+        `Received:\n` +
+        `  ${this.utils.printReceived(received)}`
+    : () => {
+        const diffString = diff(expected, received, { expand: this.expand });
+        return (
+          this.utils.matcherHint('.toReceiveMessage', 'WS', 'expected') +
+          '\n\n' +
+          `Expected the next received message to equal:\n` +
+          `  ${this.utils.printExpected(expected)}\n` +
+          `Received:\n` +
+          `  ${this.utils.printReceived(received)}\n\n` +
+          `Difference:\n\n${diffString}`
+        );
+      };
+
+  return {
+    actual: received,
+    expected,
+    message,
+    pass,
+  };
+});
+
+export const deriveToHaveReceivedMessage = (name: string, fn: RawMatcherFn): RawMatcherFn => {
+  return function (ws: WS, expected: Array<DeserializedMessage>) {
+    const isWS = ws instanceof WS;
+    if (!isWS) {
+      return {
+        pass: this.isNot, // always fail
+        message: makeInvalidWsMessage.bind(this, ws, name),
+      };
+    }
+
+    const result = fn.bind(this)(ws.messages, expected);
+    return { name, ...result };
+  };
+};
+
+const toHaveReceivedMessages = deriveToHaveReceivedMessage(
+  'toHaveReceivedMessages',
+  function (received: Array<DeserializedMessage>, expected: Array<DeserializedMessage>) {
+    const equalities = expected.map((expectedMsg) =>
+      // object comparison to handle JSON protocols
+      received.some((receivedMsg) => this.equals(receivedMsg, expectedMsg))
+    );
+    const pass = this.isNot ? equalities.some(Boolean) : equalities.every(Boolean);
 
     const message = pass
       ? () =>
-          this.utils.matcherHint('.not.toReceiveMessage', 'WS', 'expected') +
+          this.utils.matcherHint('.not.toHaveReceivedMessages', 'WS', 'expected') +
           '\n\n' +
-          `Expected the next received message to not equal:\n` +
+          `Expected the WS server to not have received the following messages:\n` +
           `  ${this.utils.printExpected(expected)}\n` +
-          `Received:\n` +
+          `But it received:\n` +
           `  ${this.utils.printReceived(received)}`
       : () => {
-          const diffString = diff(expected, received, { expand: this.expand });
           return (
-            this.utils.matcherHint('.toReceiveMessage', 'WS', 'expected') +
+            this.utils.matcherHint('.toHaveReceivedMessages', 'WS', 'expected') +
             '\n\n' +
-            `Expected the next received message to equal:\n` +
+            `Expected the WS server to have received the following messages:\n` +
             `  ${this.utils.printExpected(expected)}\n` +
             `Received:\n` +
-            `  ${this.utils.printReceived(received)}\n\n` +
-            `Difference:\n\n${diffString}`
+            `  ${this.utils.printReceived(received)}\n\n`
           );
         };
 
@@ -98,50 +154,12 @@ expect.extend({
       actual: received,
       expected,
       message,
-      name: 'toReceiveMessage',
       pass,
     };
-  },
+  }
+);
 
-  toHaveReceivedMessages(ws: WS, messages: Array<DeserializedMessage>) {
-    const isWS = ws instanceof WS;
-    if (!isWS) {
-      return {
-        pass: this.isNot, // always fail
-        message: makeInvalidWsMessage.bind(this, ws, 'toHaveReceivedMessages'),
-      };
-    }
-
-    const received = messages.map((expected) =>
-      // object comparison to handle JSON protocols
-      ws.messages.some((actual) => this.equals(actual, expected))
-    );
-    const pass = this.isNot ? received.some(Boolean) : received.every(Boolean);
-    const message = pass
-      ? () =>
-          this.utils.matcherHint('.not.toHaveReceivedMessages', 'WS', 'expected') +
-          '\n\n' +
-          `Expected the WS server to not have received the following messages:\n` +
-          `  ${this.utils.printExpected(messages)}\n` +
-          `But it received:\n` +
-          `  ${this.utils.printReceived(ws.messages)}`
-      : () => {
-          return (
-            this.utils.matcherHint('.toHaveReceivedMessages', 'WS', 'expected') +
-            '\n\n' +
-            `Expected the WS server to have received the following messages:\n` +
-            `  ${this.utils.printExpected(messages)}\n` +
-            `Received:\n` +
-            `  ${this.utils.printReceived(ws.messages)}\n\n`
-          );
-        };
-
-    return {
-      actual: ws.messages,
-      expected: messages,
-      message,
-      name: 'toHaveReceivedMessages',
-      pass,
-    };
-  },
+expect.extend({
+  toReceiveMessage,
+  toHaveReceivedMessages,
 });

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -68,7 +68,7 @@ export const deriveToReceiveMessage = (name: string, fn: RawMatcherFn): RawMatch
       };
     } else {
       const received = messageOrTimeout;
-      const result = await Promise.resolve(fn.bind(this)(received, expected, options));
+      const result = await Promise.resolve(fn.call(this, received, expected, options));
 
       return { name, ...result };
     }
@@ -117,7 +117,7 @@ export const deriveToHaveReceivedMessage = (name: string, fn: RawMatcherFn): Raw
       };
     }
 
-    const result = fn.bind(this)(ws.messages, expected);
+    const result = fn.call(this, ws.messages, expected);
     return { name, ...result };
   };
 };

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -108,7 +108,7 @@ const toReceiveMessage = deriveToReceiveMessage('toReceiveMessage', function (re
 });
 
 export const deriveToHaveReceivedMessage = (name: string, fn: RawMatcherFn): RawMatcherFn => {
-  return function (ws: WS, expected: Array<DeserializedMessage>) {
+  return function (ws: WS, expected: Array<DeserializedMessage>, options?: unknown) {
     const isWS = ws instanceof WS;
     if (!isWS) {
       return {
@@ -117,7 +117,7 @@ export const deriveToHaveReceivedMessage = (name: string, fn: RawMatcherFn): Raw
       };
     }
 
-    const result = fn.call(this, ws.messages, expected);
+    const result = fn.call(this, ws.messages, expected, options);
     return { name, ...result };
   };
 };


### PR DESCRIPTION
Added custom matcher factories since default WS matchers `toReceiveMessage` and `toHaveReceivedMessages` can only check deep equality. I know that there is room for consideration in factories' interface or name. Please review.