### PR TITLE
Fix steps to mock non-global WebSocket in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ export { WebSocket as default } from 'mock-socket';
 
 - Somewhere in the test files, call `vi.mock` with the name of the library you want to mock. For instance, for the `ws` library:
 
-
 ```js
 // foo.test.js
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ under the hood to mock out WebSocket clients.
 Out of the box, Mock Socket will only mock out the global `WebSocket` object.
 If you are using a third-party WebSocket client library (eg. a Node.js
 implementation, like [`ws`](https://github.com/websockets/ws)), you'll need
-to set up a [manual mock](https://jestjs.io/docs/en/manual-mocks#mocking-node-modules):
+to set up a [manual mock](https://vitest.dev/api/vi.html#vi-mock):
 
 - Create a `__mocks__` folder in your project root
 - Add a new file in the `__mocks__` folder named after the library you want to
@@ -331,6 +331,20 @@ to set up a [manual mock](https://jestjs.io/docs/en/manual-mocks#mocking-node-mo
 // __mocks__/ws.js
 
 export { WebSocket as default } from 'mock-socket';
+```
+
+- Somewhere in the test files, call `vi.mock` with the name of the library you want to mock. For instance, for the `ws` library:
+
+
+```js
+// foo.test.js
+
+import WebSocket from 'ws';
+import { vi } from 'vitest';
+
+vi.mock('ws');
+
+// do some tests...
 ```
 
 **NOTE** The `ws` library is not 100% compatible with the browser API, and


### PR DESCRIPTION
In vitest, modules are not mocked automatically like Jest unless we explicitly call `vi.mock()`. 

cf. https://vitest.dev/api/vi.html#vi-mock

> Beware that if you don't call vi.mock, modules are not mocked automatically. To replicate Jest's automocking behaviour, you can call vi.mock for each required module inside [setupFiles](https://vitest.dev/config/#setupfiles).