### PR TITLE
Fix examples/redux-saga build error and cover example builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,13 @@ jobs:
           cd examples/redux-saga
           npm install
           npm test -- --coverage
+          npm run build
       - name: test examples/hooks
         run: |
           cd examples/hooks
           npm install
           npm test -- --coverage
+          npm run build
 
   coverage:
     needs: build

--- a/examples/redux-saga/src/store/reducer.ts
+++ b/examples/redux-saga/src/store/reducer.ts
@@ -32,21 +32,21 @@ export const actions: { [actionName: string]: ActionFunctionAny<Action<unknown>>
   CONNECTION_LOST: (): Connection => ({ connected: false }),
 });
 
-const reducer = handleActions(
+const reducer = handleActions<State, Message | Connection>(
   {
-    [combineActions(actions.storeReceivedMessage, actions.storeSentMessage)]: (
+    [combineActions(actions.storeReceivedMessage, actions.storeSentMessage) as unknown as string]: (
       state: State,
-      { payload }: { payload: Message }
+      { payload }: { payload: Message | Connection }
     ) => ({
       ...state,
-      messages: [...state.messages, payload],
+      messages: [...state.messages, payload as Message],
     }),
-    [combineActions(actions.connectionSuccess, actions.connectionLost)]: (
+    [combineActions(actions.connectionSuccess, actions.connectionLost) as unknown as string]: (
       state: State,
-      { payload: { connected } }: { payload: Connection }
+      { payload }: { payload: Message | Connection }
     ) => ({
       ...state,
-      connected,
+      connected: (payload as Connection).connected,
     }),
   },
   defaultState


### PR DESCRIPTION
## Summary
- Fix `examples/redux-saga`'s `npm run build` (`tsc && vite build`), which was failing with a `TS2464` computed-property-name error plus follow-on overload-resolution errors in `src/store/reducer.ts`. `redux-actions`' typings require a single `Payload` type per `handleActions` call and don't type `combineActions()`'s return value as a valid computed property key, even though at runtime it works via a custom `toString()`. Fixed by widening the reducer's `Payload` generic to `Message | Connection` and casting the `combineActions()` keys to `string`.
- This had been silently broken because CI only ran `npm test` for the example apps and never `npm run build`. Added a `npm run build` step for both `examples/redux-saga` and `examples/hooks` in `.github/workflows/ci.yml` so future build regressions are caught.
- `examples/hooks` already built successfully; no code changes needed there, just the new CI step.

## Test plan
- [x] `examples/redux-saga`: `npm run build` succeeds, `npm test` → 14/14 pass, `npm run lint` unaffected by this change
- [x] `examples/hooks`: `npm run build` succeeds, `npm test` → 3/3 pass
- [x] Confirmed the CI workflow change actually invokes the failing command (`npm run build`) for both examples

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>