### PR TITLE
ci: enable npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,16 +2,17 @@ name: Publish Package to npmjs
 on:
   release:
     types: [published]
+permissions:
+  id-token: write
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '22.14.0'
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- npmjs side already has a trusted publisher configured for this repo (no environment restriction).
- `publish.yml` still authenticated via `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN` and never requested an OIDC token, so it wasn't actually using trusted publishing.
- Add `permissions: id-token: write`, bump Node to `22.14.0` (npm CLI `>=11.5.1` is required for OIDC support), bump `actions/checkout`/`actions/setup-node` to v4, and remove the token-based auth.

## Test plan
- [ ] Cut a GitHub release and confirm `npm publish` succeeds via OIDC without `NPM_TOKEN` set
- [ ] Confirm the published package shows a provenance attestation on npmjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)