### PR TITLE
fix(ci): bump publish workflow to Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm publish


### PR DESCRIPTION
## Summary
- The v0.6.0 release attempt failed with `npm error 404 Not Found - PUT .../vitest-websocket-mock` because the publish job authenticated with neither a token nor OIDC.
- Root cause: Node 22.14.0 still bundles npm 10.x. Trusted publishing (OIDC) requires npm CLI `>=11.5.1`, which is only bundled starting with Node 24. With `NODE_AUTH_TOKEN` removed in #61, npm 10 attempted an unauthenticated publish, and the registry returned a 404 (its standard response for unauthenticated access to a package it won't disclose).
- Bump `node-version` from `22.14.0` to `24` so the workflow actually gets an OIDC-capable npm CLI.

## Test plan
- [ ] Cut a new GitHub release and confirm `npm publish` succeeds via OIDC
- [ ] Confirm the published package shows a provenance attestation on npmjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)