### PR TITLE
chore: apply Biome to examples/ and verify lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,14 @@ jobs:
         run: |
           cd examples/redux-saga
           npm install
+          npm run lint
           npm test -- --coverage
           npm run build
       - name: test examples/hooks
         run: |
           cd examples/hooks
           npm install
+          npm run lint
           npm test -- --coverage
           npm run build
 

--- a/examples/hooks/biome.json
+++ b/examples/hooks/biome.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "includes": ["**", "!examples"] },
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true, "root": "../.." },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/examples/hooks/package-lock.json
+++ b/examples/hooks/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -34,16 +35,8 @@
         "mock-socket": "^9.2.1"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@biomejs/biome": "^2.5.3",
         "@vitest/coverage-v8": "4.1.1",
-        "eslint": "^8.38.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-config-react-app": "^7.0.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.3.4",
-        "eslint-plugin-simple-import-sort": "^10.0.0",
-        "prettier": "^2.0.2",
         "rimraf": "^4.1.2",
         "tsup": "^8.5.1",
         "typescript": "^4.0.2",
@@ -94,6 +87,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.3",
+        "@biomejs/cli-darwin-x64": "2.5.3",
+        "@biomejs/cli-linux-arm64": "2.5.3",
+        "@biomejs/cli-linux-arm64-musl": "2.5.3",
+        "@biomejs/cli-linux-x64": "2.5.3",
+        "@biomejs/cli-linux-x64-musl": "2.5.3",
+        "@biomejs/cli-win32-arm64": "2.5.3",
+        "@biomejs/cli-win32-x64": "2.5.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
+      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
+      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
+      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/examples/hooks/package.json
+++ b/examples/hooks/package.json
@@ -11,6 +11,7 @@
     "vitest-websocket-mock": "file:../../"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -23,7 +24,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint .",
+    "lint": "biome check .",
     "preview": "vite preview",
     "test": "vitest"
   }

--- a/examples/hooks/src/App.tsx
+++ b/examples/hooks/src/App.tsx
@@ -3,13 +3,14 @@
  * @copyright Akiomi Kamakura 2023
  */
 
-import { ChangeEvent, FormEvent, useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from 'react';
 
-type MessageProps = { text: string; side: 'sent' | 'received' };
+type MessageProps = { id: number; text: string; side: 'sent' | 'received' };
 const Message = ({ text, side }: MessageProps) => <div>{`(${side}) ${text}`}</div>;
 
 function App() {
   const wsRef = useRef<WebSocket>();
+  const nextMessageId = useRef(0);
   const [connected, setConnected] = useState(false);
   const [messages, setMessages] = useState<MessageProps[]>([]);
   const [currentMessage, setCurrentMessage] = useState('');
@@ -18,7 +19,7 @@ function App() {
     const ws = new WebSocket(`ws://${window.location.hostname}:8080`);
     ws.onopen = () => setConnected(true);
     ws.onclose = () => setConnected(false);
-    ws.onmessage = (event) => setMessages((m) => [{ side: 'received', text: event.data }, ...m]);
+    ws.onmessage = (event) => setMessages((m) => [{ id: nextMessageId.current++, side: 'received', text: event.data }, ...m]);
     wsRef.current = ws;
   }, []);
 
@@ -32,7 +33,7 @@ function App() {
 
     wsRef.current.send(currentMessage);
     setCurrentMessage('');
-    setMessages((m) => [{ side: 'sent', text: currentMessage }, ...m]);
+    setMessages((m) => [{ id: nextMessageId.current++, side: 'sent', text: currentMessage }, ...m]);
   };
 
   return (
@@ -47,13 +48,14 @@ function App() {
       />
 
       <div className="Messages">
-        {messages.map((message, i) => (
-          <Message key={i} {...message} />
+        {messages.map((message) => (
+          <Message key={message.id} {...message} />
         ))}
       </div>
 
       <form className="MessageForm" onSubmit={send}>
         <input
+          // biome-ignore lint/a11y/noAutofocus: intentional for this chat demo's single input field
           autoFocus
           className="MessageInput"
           value={currentMessage}

--- a/examples/hooks/src/styles.css
+++ b/examples/hooks/src/styles.css
@@ -9,8 +9,9 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/examples/redux-saga/biome.json
+++ b/examples/redux-saga/biome.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "includes": ["**", "!examples"] },
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true, "root": "../.." },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/examples/redux-saga/package-lock.json
+++ b/examples/redux-saga/package-lock.json
@@ -16,6 +16,7 @@
         "redux-saga": "^1.2.3"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -39,16 +40,8 @@
         "mock-socket": "^9.2.1"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@biomejs/biome": "^2.5.3",
         "@vitest/coverage-v8": "4.1.1",
-        "eslint": "^8.38.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-config-react-app": "^7.0.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.3.4",
-        "eslint-plugin-simple-import-sort": "^10.0.0",
-        "prettier": "^2.0.2",
         "rimraf": "^4.1.2",
         "tsup": "^8.5.1",
         "typescript": "^4.0.2",
@@ -98,6 +91,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
+      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.3",
+        "@biomejs/cli-darwin-x64": "2.5.3",
+        "@biomejs/cli-linux-arm64": "2.5.3",
+        "@biomejs/cli-linux-arm64-musl": "2.5.3",
+        "@biomejs/cli-linux-x64": "2.5.3",
+        "@biomejs/cli-linux-x64-musl": "2.5.3",
+        "@biomejs/cli-win32-arm64": "2.5.3",
+        "@biomejs/cli-win32-x64": "2.5.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
+      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
+      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
+      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/examples/redux-saga/package.json
+++ b/examples/redux-saga/package.json
@@ -15,6 +15,7 @@
     "vitest-websocket-mock": "file:../../"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -28,7 +29,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint .",
+    "lint": "biome check .",
     "preview": "vite preview",
     "test": "vitest"
   }

--- a/examples/redux-saga/src/MessageInput.tsx
+++ b/examples/redux-saga/src/MessageInput.tsx
@@ -25,6 +25,7 @@ class MessageInput extends PureComponent<{ send: ActionFunctionAny<Action<unknow
     return (
       <form className="MessageForm" onSubmit={this.onSubmit}>
         <input
+          // biome-ignore lint/a11y/noAutofocus: intentional for this chat demo's single input field
           autoFocus
           className="MessageInput"
           value={message}

--- a/examples/redux-saga/src/Messages.tsx
+++ b/examples/redux-saga/src/Messages.tsx
@@ -12,6 +12,7 @@ const Message = ({ text, side }: MessageT) => <div>{`(${side}) ${text}`}</div>;
 const Messages = ({ messages }: { messages: MessageT[] }) => (
   <div className="Messages">
     {messages.map((message, i) => (
+      // biome-ignore lint/suspicious/noArrayIndexKey: messages array only ever grows via append, so index is a stable identity
       <Message key={i} {...message} />
     ))}
   </div>

--- a/examples/redux-saga/src/__tests__/saga.test.ts
+++ b/examples/redux-saga/src/__tests__/saga.test.ts
@@ -107,7 +107,9 @@ describe('The saga', () => {
     expect(store.getState().connected).toBe(false);
 
     // Trigger our delayed reconnection
-    spy.mock.calls.forEach(([cb, , ...args]) => cb(...args));
+    spy.mock.calls.forEach(([cb, , ...args]) => {
+      cb(...args);
+    });
 
     await ws.connected; // reconnected!
     expect(store.getState().connected).toBe(true);

--- a/examples/redux-saga/src/store/saga.ts
+++ b/examples/redux-saga/src/store/saga.ts
@@ -5,8 +5,7 @@
 import type { Action } from 'redux';
 import type { EventChannel } from 'redux-saga';
 import { END, eventChannel } from 'redux-saga';
-import { call, cancel, delay, fork, put, take } from 'redux-saga/effects';
-import { Effect } from 'redux-saga/effects';
+import { call, cancel, delay, type Effect, fork, put, take } from 'redux-saga/effects';
 
 import { actions } from './reducer';
 
@@ -33,7 +32,7 @@ function websocketInitChannel(connection: WebSocket): EventChannel<Action<unknow
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: generator return type follows redux-saga's own typing convention
 function* sendMessage<A>(connection: WebSocket): Generator<Effect, A, any> {
   while (true) {
     const { payload } = yield take(actions.send);
@@ -42,7 +41,7 @@ function* sendMessage<A>(connection: WebSocket): Generator<Effect, A, any> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: generator return type follows redux-saga's own typing convention
 export default function* saga<A>(): Generator<Effect, A, any> {
   const connection = new WebSocket(`ws://${window.location.hostname}:8080`);
   const channel = yield call(websocketInitChannel, connection);

--- a/examples/redux-saga/src/styles.css
+++ b/examples/redux-saga/src/styles.css
@@ -9,8 +9,9 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- Give each example (`examples/hooks`, `examples/redux-saga`) its own `@biomejs/biome` devDependency and `biome.json`, since each is an isolated npm project with its own `npm install` in CI
- Their `"lint": "eslint ."` scripts were dead — `eslint` was never a dependency there and CI never called `npm run lint` for examples. Swapped to `biome check .` and added an explicit `npm run lint` step to each example's CI block, restoring the coverage the old root ESLint config used to provide by accident (it reached into `examples/` since there was no local override) before the Biome migration scoped it out
- Fixed the real issues Biome's recommended preset (JSX/a11y rules included) found in the example apps:
  - `hooks`: messages are prepended to the list, so array-index keys weren't a stable identity — switched to a monotonic id
  - `redux-saga`: a `forEach` callback in a saga test implicitly returned a value
  - import sorting / formatting in both
- Suppressed two rules with `biome-ignore` + reason where the pattern is intentional/safe: `autoFocus` on each demo's single chat input, and array-index keys in `redux-saga` (list is append-only there, so index is stable)
- Replaced now-dead `eslint-disable` comments with `biome-ignore` equivalents
- Root `biome.json` still excludes `examples/**` — each example now lints itself independently
- Also fixed a Biome deprecation warning (`rules.recommended` → `rules.preset`) in all three `biome.json` files while touching them

## Test plan
- [x] `npm test` / `npm run lint` / `npm run build` at root
- [x] `npm run lint` / `npm test` / `npm run build` in `examples/hooks`
- [x] `npm run lint` / `npm test` / `npm run build` in `examples/redux-saga`