### PR TITLE
chore: upgrade TypeScript to 6.0.3 and add a dedicated typecheck step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: unset GITHUB_ACTIONS && npm test
+      - run: npm run typecheck
       - run: npm run lint
       - run: npm run build
       - run: npm pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,11 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.3",
+        "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "4.1.1",
         "rimraf": "^4.1.2",
         "tsup": "^8.5.1",
-        "typescript": "^4.0.2",
+        "typescript": "^6.0.3",
         "vite": "^8.1.4",
         "vitest": "4.1.1"
       },
@@ -1550,6 +1551,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.1.tgz",
@@ -3013,9 +3024,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3023,13 +3034,20 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
     "build": "tsup",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome check --write .",
     "prepublishOnly": "npm run build",
@@ -35,10 +36,11 @@
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
+    "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "4.1.1",
     "rimraf": "^4.1.2",
     "tsup": "^8.5.1",
-    "typescript": "^4.0.2",
+    "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vitest": "4.1.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,13 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["esnext", "dom"],
     "strict": true,
     "esModuleInterop": true,
-    "ignoreDeprecations": "5.0",
+    "skipLibCheck": true,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
     "isolatedModules": true,
     "declaration": true,
     "declarationMap": true


### PR DESCRIPTION
## Summary
- Upgrade `typescript` from `^4.0.2` (resolving 4.9.5) to `^6.0.3`
  - 7.0.2 (latest) is not viable yet: tsup's `.d.ts` bundling goes through `rollup-plugin-dts`, whose `typescript` peerDependency caps at `^6.0` — it crashes (`Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`) under TS7's changed internals. 6.0.3 is the newest version the whole toolchain (tsup + rollup-plugin-dts) actually supports today. Whether to drop tsup in favor of something not blocked by this is a separate question to revisit after this merges.
- Fix `tsconfig.json`, which had drifted out of sync with the actual TypeScript version (it carried `"ignoreDeprecations": "5.0"`, a TS5+-only option that silently did nothing under 4.9.5 — a leftover from a prior, never-finished version bump):
  - `moduleResolution: "node"` → `"bundler"` — the old resolver can't follow package.json `exports` subpaths (e.g. `@vitest/utils/display`), which broke type-checking against current `vitest`/`vite`
  - add `skipLibCheck: true` so dependency type errors don't leak into our own build
  - add `types: ["node"]` — `@types/node`'s ambient `require`/`module` globals aren't auto-included by TS6/7 the way they were under older versions
  - add `ignoreDeprecations: "6.0"` — tsup always injects a `baseUrl` into its internal dts compile, which TS6 now treats as a hard error without this
  - add `@types/node` as a devDependency (`^26.1.1`, matching `.node-version`)
- Add a `"typecheck": "tsc --noEmit"` script and wire it into CI right after `npm test`. Until now, type-checking only happened as a side effect of tsup's dts generation, which never reaches `src/__tests__/` since nothing in `src/index.ts`'s import graph touches those files — test code was never actually type-checked.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm pack --dry-run`