### PR TITLE
chore: enable Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add a `github-actions` entry to `.github/dependabot.yml`, alongside the existing `npm` one, so actions used in `ci.yml`/`publish.yml` (`actions/checkout`, `actions/setup-node`, `codecov/codecov-action`, etc.) get automated version-bump PRs instead of sitting pinned indefinitely
- Same `daily` schedule and `open-pull-requests-limit: 10` as the existing npm config, for consistency

## Test plan
- N/A (config-only change); Dependabot will pick this up and start opening PRs for outdated actions once merged