### PR TITLE
docs: fix stale and incorrect content in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This can be used to test behaviour for a client that connects to a WebSocket ser
 ```js
 test('rejects connections that fail the verifyClient option', async () => {
   new WS('ws://localhost:1234', { verifyClient: () => false });
-  const errorCallback = vitest.fn();
+  const errorCallback = vi.fn();
 
   await expect(
     new Promise((resolve, reject) => {
@@ -200,7 +200,7 @@ This can be used to test behaviour for a client that connects to a WebSocket ser
 test('rejects connections that fail the selectProtocol option', async () => {
   const selectProtocol = () => null;
   new WS('ws://localhost:1234', { selectProtocol });
-  const errorCallback = vitest.fn();
+  const errorCallback = vi.fn();
 
   await expect(
     new Promise((resolve, reject) => {
@@ -256,7 +256,7 @@ it('the server can refuse connections', async () => {
   });
 
   const client = new WebSocket('ws://localhost:1234');
-  client.onclose = (event: CloseEvent) => {
+  client.onclose = (event) => {
     expect(event.code).toBe(1003);
     expect(event.wasClean).toBe(false);
     expect(event.reason).toBe('NOPE');
@@ -292,7 +292,7 @@ afterEach(() => {
 
 `mock-socket` has a strong usage of delays (`setTimeout` to be more specific). This means using `vi.useFakeTimers();` will cause issues such as the client appearing to never connect to the server.
 
-While running the websocket server from tests within the vitest-dom environment (as opposed to node)
+While running the websocket server from tests within the jsdom environment (as opposed to node)
 you may see errors of the nature:
 
 ```bash
@@ -306,7 +306,7 @@ adding `require('setimmediate');` to your `setupTests.js`.
 ## Testing React applications
 
 When testing React applications, `vitest-websocket-mock` will look for
-`@testing-library/react`'s implementation of [`act`](https://reactjs.org/docs/test-utils.html#act).
+`@testing-library/react`'s implementation of [`act`](https://react.dev/reference/react/act).
 If it is available, it will wrap all the necessary calls in `act`, so you don't have to.
 
 If `@testing-library/react` is not available, we will assume that you're not testing a React application,


### PR DESCRIPTION
## Summary
Reviewed README.md for outdated/incorrect content, with a focus on the React-related section per request. Found and fixed:

- **Dead-ish link**: the `act()` docs link pointed at `reactjs.org`, which now 308-redirects to `legacy.reactjs.org` (React's pre-`react.dev` archive). Updated to the current canonical page.
- **Copy-paste footgun**: two examples used `vitest.fn()` with no import shown. That only works if the reader's project has `globals: true` configured — this repo's own `vite.config.ts` doesn't, and neither do the examples. Every other example in the doc (and the actual test suite) uses `vi.fn()`, so switched to match.
- **Invalid syntax in a ` ```js ` block**: `client.onclose = (event: CloseEvent) => {...}` has a TypeScript type annotation inside a fence labeled as plain JS. Dropped the annotation.
- **Nonexistent environment name**: "the vitest-dom environment" isn't a real Vitest option (Vitest's are `node`/`jsdom`/`happy-dom`/`edge-runtime`). Checked upstream [romgain/jest-websocket-mock](https://github.com/romgain/jest-websocket-mock)'s README and confirmed this line originally said "jest-dom" (Jest's default jsdom environment) — a leftover from a mechanical jest→vitest find-replace during the fork. Fixed to "jsdom".

Everything else checked out: the documented `WS` API (constructor, `connected`/`closed`/`nextMessage`, `send`/`close`/`error`/`on`) matches `src/websocket.ts`, the `.toReceiveMessage` 1000ms default timeout matches `src/derivers/deriveToReceiveMessage.ts`, the example links (`examples/hooks/src/App.test.tsx`, `examples/redux-saga/src/__tests__/{saga,App}.test.ts(x)`) all resolve to real files, and the other external links (mock-socket, ws, setImmediate shim, vitest.dev) are still live and on-topic.

## Test plan
- N/A (docs-only change)