### PR TITLE
chore: update .npmignore for current tooling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,15 +2,12 @@
 coverage
 examples
 node_modules
-.eslintignore
-.eslintrc.cjs
+biome.json
 .gitignore
 .node-version
 .npmignore
 .npmrc
-.prettierignore
-.prettierrc
 tsconfig.json
-tsup.config.ts
+tsdown.config.ts
 vite.config.ts
 *.tgz


### PR DESCRIPTION
## Summary
Full-repo modernization audit turned up one loose end: `.npmignore` still listed `.eslintignore`, `.eslintrc.cjs`, `.prettierignore`, `.prettierrc`, and `tsup.config.ts` — all deleted months ago across the Biome and tsdown migrations. Swapped them for the current equivalents (`biome.json`, `tsdown.config.ts`).

Note this is purely a hygiene fix: `package.json`'s `"files": ["dist", "LICENSE"]` allowlist already takes precedence over `.npmignore` for what actually gets published, and `npm pack --dry-run` output (`LICENSE`, `README.md`, `package.json`, `dist/index.js`, `dist/index.d.ts` — 5 files, same shasum) is identical before and after this change.

Rest of the repo checked out clean in this audit: Node/CI/TypeScript/build tooling are all current, `npm audit` shows 0 vulnerabilities, and root + both examples pass test/typecheck/lint/build. A few dependency versions are slightly behind latest (`vitest`/`@vitest/coverage-v8`/`@vitest/utils` pinned to `4.1.1`, `rimraf` at `4.4.1`, and `actions/checkout@v3`/`actions/setup-node@v3` in `ci.yml`) — left alone since Dependabot (enabled in #69) will pick these up on its own.

## Test plan
- [x] `npm pack --dry-run` output unchanged (same 5 files, same shasum)