### PR TITLE
chore: fix noExplicitAny biome-ignore comments

### DIFF
--- a/examples/redux-saga/src/store/saga.ts
+++ b/examples/redux-saga/src/store/saga.ts
@@ -32,7 +32,6 @@ function websocketInitChannel(connection: WebSocket): EventChannel<Action<unknow
   });
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: generator return type follows redux-saga's own typing convention
 function* sendMessage<A>(connection: WebSocket): Generator<Effect, A, any> {
   while (true) {
     const { payload } = yield take(actions.send);
@@ -41,7 +40,6 @@ function* sendMessage<A>(connection: WebSocket): Generator<Effect, A, any> {
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: generator return type follows redux-saga's own typing convention
 export default function* saga<A>(): Generator<Effect, A, any> {
   const connection = new WebSocket(`ws://${window.location.hostname}:8080`);
   const channel = yield call(websocketInitChannel, connection);

--- a/src/__tests__/websocket.test.ts
+++ b/src/__tests__/websocket.test.ts
@@ -281,8 +281,8 @@ describe('The WS helper', () => {
     const client = new WebSocket('ws://localhost:1234');
     await server.connected;
 
-    // biome-ignore lint/suspicious/noExplicitAny: test helper casts to access matcher internals
-    let error: any; // bad types in MockSockets
+    // biome-ignore lint/suspicious/noExplicitAny: mock-socket types onerror's event as Event, which lacks the origin/type fields present at runtime
+    let error: any;
     let disconnected = false;
     client.onclose = () => {
       disconnected = true;


### PR DESCRIPTION
## Summary
- `websocket.test.ts`: the `biome-ignore` reason was copy-pasted from an unrelated "matcher internals cast" comment; the actual reason `error: any` exists is that mock-socket types `onerror`'s event as plain `Event`, which lacks the `origin`/`type` fields accessed here at runtime.
- `examples/redux-saga/saga.ts`: `examples/` is excluded from Biome linting entirely (`biome.json` `files.includes: ["**", "!examples"]`), confirmed with `npx biome check` reporting the file as ignored. The two `biome-ignore` comments there have no effect and were removed as dead weight; the `any` typing itself (redux-saga's own `Generator<Effect, A, any>` convention) is unchanged.

## Test plan
- [x] `npx biome check` on changed `src` file shows no noExplicitAny violations
- [x] `npm test` — all 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)