### PR TITLE
chore: remove unrecognized resolution-mode from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest


### PR DESCRIPTION
## Summary
- `resolution-mode` is a pnpm-only config option and is not recognized by npm, which this project uses (`package-lock.json`)
- npm prints `npm warn Unknown project config "resolution-mode"...` on every `npm run` invocation because of this leftover setting
- Removing it silences the warning with no behavior change

## Test plan
- [x] `npm config list` no longer shows the "Unknown project config" warning