### PR TITLE
ci(dependabot): group vitest updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    groups:
+      # `@vitest/coverage-v8` pins `vitest` with an exact peer dependency, so a
+      # PR that bumps only one of them can never install. Keep them together.
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
## Verdict: yes, they should be grouped

`@vitest/coverage-v8` pins `vitest` with an **exact** peer dependency:

```
$ npm view @vitest/coverage-v8@5.0.0 peerDependencies
{ vitest: '5.0.0', '@vitest/browser': '5.0.0' }
```

That is `5.0.0` itself, not a caret range, so a PR that bumps only one of the
two can never install. Both #115 and #117 died at `npm ci` with `ERESOLVE` and
never ran a single test. This is not limited to majors — the same thing happens
across a gap as small as 4.1.10 to 4.1.11.

```yaml
groups:
  vitest:
    patterns:
      - 'vitest'
      - '@vitest/*'
```

## Trade-offs

**What this buys**

- The lockfile Dependabot produces is actually installable. Today every vitest
  release opens two PRs that are both guaranteed to fail.
- Half as many PRs. With `schedule: daily` and vitest's release cadence, that
  is not a small difference.
- The `@vitest/*` pattern covers packages we may add later (`@vitest/ui`,
  `@vitest/coverage-istanbul`, ...), which carry the same exact peer pin.

**What this does not buy — to be clear about it**

- Grouping only fixes the **dependency resolution conflict**. Source changes
  required by a major update are still manual work: the 4 to 5 bump needed a
  type migration for the removal of `@vitest/expect` (#118). After grouping,
  such a PR fails at typecheck instead of at `npm ci`.
- A grouped PR makes it slightly harder to isolate which dependency broke. In
  this case that costs nothing, since the two split PRs were failing for the
  same reason anyway.

## Considered but not included

Adding `vite` to the group. Vitest 5 declares its `vite` peer as a range
(`^6.4.0 || ^7.0.0 || ^8.0.0`), so vite can currently move independently
without breaking anything. If a future vite major lands before vitest supports
it, the same `ERESOLVE` would appear and that is the moment to add it. Adding
it now would bundle unrelated vite patch updates into the vitest PRs and make
the diffs larger for no benefit.

## Related

#118 is the actual version bump. This config change alone does not fix the
existing #115 / #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J4qKCjj4CnJ1bHCYQP4JJ