### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-10
+
 ### Changed
 
 - **Breaking:** Vitest 5 is now required (`peerDependencies`: `>=4` to `>=5 <6`). The matcher types are now declared against `vitest` instead of `@vitest/expect`, which Vitest 5 no longer depends on. Vitest 4 and 5 declare `Matchers` with different type parameters, so one build cannot support both.
@@ -37,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `tsup` and `vite` (dev dependencies) to fix vulnerable dependencies.
 - Update `vite` in examples to fix a vulnerable dependency.
 
-[Unreleased]: https://github.com/akiomik/vitest-websocket-mock/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/akiomik/vitest-websocket-mock/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/akiomik/vitest-websocket-mock/releases/tag/v0.8.0
 [0.7.0]: https://github.com/akiomik/vitest-websocket-mock/releases/tag/v0.7.0
 [0.6.0]: https://github.com/akiomik/vitest-websocket-mock/releases/tag/v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitest-websocket-mock",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vitest-websocket-mock",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "mock-socket": "^9.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-websocket-mock",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Mock websockets and assert complex websocket interactions with Vitest",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Release prep for 0.8.0.

Minor rather than patch because #118 is a breaking change: `peerDependencies`
moved from `>=4` to `>=5 <6`, and the matcher return types changed. The project
is on 0.x, where SemVer does not require a major for breaking changes, and the
existing history uses minor bumps for them (0.6.0 and 0.7.0 both carried
breaking changes).

Same three files as every previous release: `package.json`, `package-lock.json`,
and the `CHANGELOG.md` heading plus its compare/release links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J4qKCjj4CnJ1bHCYQP4JJ