### PR TITLE
docs: write down the release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,8 @@ and does `npm ci && npm publish`, authenticating to npm with OIDC trusted
 publishing. There is no npm token to manage. Creating the GitHub release is
 therefore the point of no return.
 
+Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
+
 ## Steps
 
 1. Make sure `main` is green and clean, and that no dependency PR you intend to
@@ -15,35 +17,54 @@ therefore the point of no return.
    ```bash
    git switch -c chore-bump-version-to-X.Y.Z
    npm version X.Y.Z --no-git-tag-version
+   (cd examples/hooks && npm install --package-lock-only)
+   (cd examples/redux-saga && npm install --package-lock-only)
    ```
 
    `npm version` updates `package.json` and both version fields in
-   `package-lock.json`. Then edit `CHANGELOG.md` by hand:
+   `package-lock.json`. The examples need the second pair of commands because
+   they link the root package with `file:../..`, and npm copies its manifest —
+   `version` and `peerDependencies` included — into their lockfiles under the
+   `../..` entry. Skipping this leaves them pointing at the previous release;
+   0.7.0 shipped that way.
+
+   Then edit `CHANGELOG.md` by hand:
 
    - insert `## [X.Y.Z] - YYYY-MM-DD` directly under `## [Unreleased]`, leaving
      `## [Unreleased]` empty;
    - repoint the `[Unreleased]` compare link at the new tag and add an
      `[X.Y.Z]` release link above the previous one.
 
-   The diff should touch those three files and nothing else.
-
 3. Open a PR titled `chore: bump version to X.Y.Z`, wait for CI, and merge it.
    The repository merges with merge commits, so individual commit messages land
    on `main`.
 
-4. Create the release from `main`. The notes are the changelog section for this
-   version with `###` promoted to `##`:
+4. Create the release from the bump PR's merge commit, not from `main`, so that
+   anything merged in the meantime cannot end up inside the tag:
 
    ```bash
-   gh release create vX.Y.Z --target main --title vX.Y.Z --notes-file notes.md
+   awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md \
+     | sed 's/^### /## /' > notes.md
+
+   gh release create vX.Y.Z \
+     --target "$(gh pr view N --json mergeCommit --jq .mergeCommit.oid)" \
+     --title vX.Y.Z --notes-file notes.md
    ```
 
-5. Watch the publish run and confirm the version is live:
+   The `awk` pulls out this version's changelog section and the `sed` promotes
+   its `###` headings to `##`, matching how previous releases were written.
+
+5. Confirm the publish. Select the run by tag — `--limit 1` alone can hand you
+   the *previous* release's run if this one has not been queued yet, which looks
+   identical to success:
 
    ```bash
-   gh run list --workflow=publish.yml --limit 1
-   npm view vitest-websocket-mock version
+   gh run list --workflow=publish.yml --branch vX.Y.Z
+   npm view vitest-websocket-mock@X.Y.Z version
    ```
+
+   `npm view` can lag behind for a few minutes on the `latest` tag even after the
+   run succeeds; asking for the exact version, as above, bypasses that.
 
 ## Choosing the version
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,9 +39,13 @@ Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
    nothing above is staged for you:
 
    ```bash
-   git add -A
+   git add package.json package-lock.json examples/*/package-lock.json CHANGELOG.md
    git commit -m "chore: bump version to X.Y.Z"
    ```
+
+   Those five paths are the whole of a version bump. Staging them by name rather
+   than with `git add -A` keeps anything else in your working tree out of the
+   release commit, and makes an unexpectedly empty stage visible.
 
 3. Open a PR titled `chore: bump version to X.Y.Z`, wait for CI, and merge it.
    The repository merges with merge commits, so individual commit messages land
@@ -51,24 +55,33 @@ Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
    anything merged in the meantime cannot end up inside the tag:
 
    ```bash
+   version=X.Y.Z
    target=$(gh pr view N --json mergeCommit --jq '.mergeCommit.oid // empty')
-   notes=$(awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md \
-             | sed 's/^### /## /')
+   notes=$(awk -v v="$version" 'index($0,"## [" v "]")==1{f=1;next} /^## \[/{f=0} f' \
+             CHANGELOG.md | sed 's/^### /## /')
 
-   if [ -z "$target" ]; then
-     echo "PR N is not merged yet - refusing to tag"
+   if [ -z "$target" ] || [ -z "$notes" ]; then
+     echo "PR N unmerged, or no changelog section for $version - refusing to tag"
    else
-     gh release create vX.Y.Z --target "$target" --title vX.Y.Z --notes "$notes"
+     gh release create "v$version" --target "$target" \
+       --title "v$version" --notes "$notes"
    fi
    ```
 
    The `awk` pulls out this version's changelog section and the `sed` promotes
    its `###` headings to `##`, matching how previous releases were written.
 
-   Do not drop the guard. `gh pr view` prints nothing and still exits 0 while a
-   PR is unmerged, and it can lag briefly right after a merge; an empty
-   `--target` is not an error, it silently tags the default branch instead —
-   the one thing this step exists to prevent.
+   Do not drop either half of the guard, and keep the version in one variable.
+   Both inputs fail quietly:
+
+   - `gh pr view` prints nothing and still exits 0 while a PR is unmerged, and
+     it can lag briefly right after a merge. An empty `--target` is not an
+     error — it silently tags the default branch, the one thing this step
+     exists to prevent.
+   - `awk` prints nothing if the changelog has no matching heading. `gh` only
+     checks that `--notes` was passed, not that it is non-empty, so the release
+     is created with an empty body and publishing starts. That one is
+     recoverable with `gh release edit --notes`; the tag is not.
 
 5. Confirm the publish. Select the run by tag — `--limit 1` alone can hand you
    the *previous* release's run if this one has not been queued yet, which looks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing
+
+Publishing is automated: `.github/workflows/publish.yml` runs on `release: published`
+and does `npm ci && npm publish`, authenticating to npm with OIDC trusted
+publishing. There is no npm token to manage. Creating the GitHub release is
+therefore the point of no return.
+
+## Steps
+
+1. Make sure `main` is green and clean, and that no dependency PR you intend to
+   include is still open.
+
+2. Bump the version on a branch named `chore-bump-version-to-X.Y.Z`:
+
+   ```bash
+   git switch -c chore-bump-version-to-X.Y.Z
+   npm version X.Y.Z --no-git-tag-version
+   ```
+
+   `npm version` updates `package.json` and both version fields in
+   `package-lock.json`. Then edit `CHANGELOG.md` by hand:
+
+   - insert `## [X.Y.Z] - YYYY-MM-DD` directly under `## [Unreleased]`, leaving
+     `## [Unreleased]` empty;
+   - repoint the `[Unreleased]` compare link at the new tag and add an
+     `[X.Y.Z]` release link above the previous one.
+
+   The diff should touch those three files and nothing else.
+
+3. Open a PR titled `chore: bump version to X.Y.Z`, wait for CI, and merge it.
+   The repository merges with merge commits, so individual commit messages land
+   on `main`.
+
+4. Create the release from `main`. The notes are the changelog section for this
+   version with `###` promoted to `##`:
+
+   ```bash
+   gh release create vX.Y.Z --target main --title vX.Y.Z --notes-file notes.md
+   ```
+
+5. Watch the publish run and confirm the version is live:
+
+   ```bash
+   gh run list --workflow=publish.yml --limit 1
+   npm view vitest-websocket-mock version
+   ```
+
+## Choosing the version
+
+The project is on 0.x, where SemVer permits breaking changes in a minor. The
+history follows that: 0.6.0 and 0.7.0 both carried breaking changes, and so did
+0.8.0 (Vitest 5 became the required peer). Use a minor for anything that changes
+the public API, the supported Vitest range, or the shipped types, and a patch
+only for fixes that leave all of those alone.
+
+Mark the breaking commit per [Conventional Commits][cc]: `!` before the `:` and
+a `BREAKING CHANGE:` footer.
+
+[cc]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,6 +35,14 @@ Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
    - repoint the `[Unreleased]` compare link at the new tag and add an
      `[X.Y.Z]` release link above the previous one.
 
+   Commit all of it. `--no-git-tag-version` suppresses npm's own commit, so
+   nothing above is staged for you:
+
+   ```bash
+   git add -A
+   git commit -m "chore: bump version to X.Y.Z"
+   ```
+
 3. Open a PR titled `chore: bump version to X.Y.Z`, wait for CI, and merge it.
    The repository merges with merge commits, so individual commit messages land
    on `main`.
@@ -43,16 +51,24 @@ Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
    anything merged in the meantime cannot end up inside the tag:
 
    ```bash
-   awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md \
-     | sed 's/^### /## /' > notes.md
+   target=$(gh pr view N --json mergeCommit --jq '.mergeCommit.oid // empty')
+   notes=$(awk '/^## \[X.Y.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md \
+             | sed 's/^### /## /')
 
-   gh release create vX.Y.Z \
-     --target "$(gh pr view N --json mergeCommit --jq .mergeCommit.oid)" \
-     --title vX.Y.Z --notes-file notes.md
+   if [ -z "$target" ]; then
+     echo "PR N is not merged yet - refusing to tag"
+   else
+     gh release create vX.Y.Z --target "$target" --title vX.Y.Z --notes "$notes"
+   fi
    ```
 
    The `awk` pulls out this version's changelog section and the `sed` promotes
    its `###` headings to `##`, matching how previous releases were written.
+
+   Do not drop the guard. `gh pr view` prints nothing and still exits 0 while a
+   PR is unmerged, and it can lag briefly right after a merge; an empty
+   `--target` is not an error, it silently tags the default branch instead —
+   the one thing this step exists to prevent.
 
 5. Confirm the publish. Select the run by tag — `--limit 1` alone can hand you
    the *previous* release's run if this one has not been queued yet, which looks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,8 +17,7 @@ Throughout, `X.Y.Z` is the new version and `N` the number of the bump PR.
    ```bash
    git switch -c chore-bump-version-to-X.Y.Z
    npm version X.Y.Z --no-git-tag-version
-   (cd examples/hooks && npm install --package-lock-only)
-   (cd examples/redux-saga && npm install --package-lock-only)
+   for d in examples/*/; do (cd "$d" && npm install --package-lock-only); done
    ```
 
    `npm version` updates `package.json` and both version fields in

--- a/examples/hooks/package-lock.json
+++ b/examples/hooks/package-lock.json
@@ -28,7 +28,7 @@
       }
     },
     "../..": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -45,7 +45,7 @@
         "vitest": "^5.0.0"
       },
       "peerDependencies": {
-        "vitest": ">=5"
+        "vitest": ">=5 <6"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/examples/redux-saga/package-lock.json
+++ b/examples/redux-saga/package-lock.json
@@ -33,7 +33,7 @@
       }
     },
     "../..": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -50,7 +50,7 @@
         "vitest": "^5.0.0"
       },
       "peerDependencies": {
-        "vitest": ">=5"
+        "vitest": ">=5 <6"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
The release process was not documented. Cutting 0.8.0 meant reconstructing it
from git history first — the version-bump commits, the changelog heading and
link conventions, and how `publish.yml` is triggered.

This records what was actually run for 0.8.0 rather than a proposal, which is
why it is written after the release and not before.

Two things worth having in writing:

- Creating the GitHub release is the point of no return. `publish.yml` runs on
  `release: published` and publishes to npm with OIDC trusted publishing, so
  there is no separate publish step to hold back.
- The version choice. The project is on 0.x, where SemVer allows breaking
  changes in a minor, and the history follows that — 0.6.0, 0.7.0 and 0.8.0 all
  carried breaking changes.

## Review round

Four findings, all valid, all fixed. Every command in the document was then
replayed against the real 0.8.0 release.

**The `notes.md` in step 4 was never created.** It now shows the extraction, and
its output matches the published v0.8.0 release notes byte for byte.

**Step 4 targeted `main`.** Anything merged between the bump merge and the
release would have been inside the tag. It now resolves the bump PR's merge
commit — `32681f0`, which is exactly what `v0.8.0` points at.

**Step 5's `gh run list --limit 1` can return the previous release's run.** This
is not hypothetical: it happened while cutting 0.8.0. The check reported the
v0.7.0 run as a success before the v0.8.0 run had been queued, which is
indistinguishable from the real thing. Selecting by `--branch vX.Y.Z` is
unambiguous. The npm check moved to `npm view pkg@X.Y.Z` for the same reason —
the `latest` tag lagged for minutes after 0.8.0 published, and `npm install`
was still resolving 0.7.0 in that window.

**"The diff should touch those three files and nothing else" institutionalized
real drift**, and this was the finding with teeth. The examples link the root
package with `file:../..`, so npm copies its manifest into their lockfiles under
the `../..` entry. Tracing it:

| commit | root | examples' lockfiles |
| --- | --- | --- |
| before the 0.7.0 bump | 0.6.0 | 0.6.0 |
| the 0.7.0 bump | 0.7.0 | **0.6.0** |
| #118 | 0.7.0 | 0.7.0 (repaired by accident) |
| the 0.8.0 bump | 0.8.0 | **0.7.0** |

So the drift is introduced by every bump and was only ever cleared when
something else happened to reinstall the examples. It had also gone stale on a
second field: `peerDependencies` still read `>=5`, from before #118 bounded it
to `>=5 <6`.

Nothing was broken — the examples install with `npm install`, which rewrites
these fields silently — but that is the point. The next contributor to touch an
example would have carried the diff. `fix(examples)` in this PR clears the
current drift, and step 2 now regenerates both lockfiles so it stops recurring.

## Second review round

Three more findings, all valid, all fixed. The document is now runnable start to
finish as written.

**`--target` could be silently empty.** `gh pr view N --json mergeCommit --jq
.mergeCommit.oid` prints nothing and exits 0 while a PR is unmerged, and it lags
briefly right after a merge. `--target ""` is not an error — GitHub tags the
default branch — so the failure is invisible, at the one step this document
calls the point of no return. The SHA now goes through a variable that is
checked before the release is created. Verified against the open #124 (guard
trips) and the merged #123 (resolves to `32681f0`, which is what `v0.8.0`
points at).

**`notes.md` was left in the repository root.** Untracked, not in `.gitignore`,
never removed — it would have contradicted step 1's "main is clean" on the next
release, and been swept up by any `git add -A` in between. Rather than add a
cleanup step, the notes now go through `--notes "$notes"` and no file is
created at all. The string is byte-identical to the published v0.8.0 notes.

**Step 2 never committed.** `--no-git-tag-version` suppresses npm's commit, so
the version bump, the example lockfiles and the changelog edit were all left
unstaged and step 3 would have opened an empty PR.

## Third review round

**`$notes` was unguarded.** `awk` prints nothing when the changelog has no
matching heading, and `gh` only checks that `--notes` was passed, not that it
holds anything, so an empty release body sails through and publishing starts.
The guard now covers both inputs.

The cause was three separate `X.Y.Z` in one snippet: substitute the `gh` ones,
forget the `awk` pattern, get silence. The version now lives in a single
variable, so the mistake is no longer available. `awk -v` with an `index()`
prefix test avoids escaping the brackets into a dynamic regex, and reproduces
the published v0.8.0 notes byte for byte. All three branches were dry-run: the
real 0.8.0 inputs tag `32681f0`, a version with no changelog section refuses, an
unmerged PR refuses.

Also picked up one of the two points the review deliberately left out. `git add
-A` is now `git add` with the five explicit paths, which keeps anything else in
the working tree out of the release commit and restores the check the original
"three files and nothing else" line was reaching for — with the right list this
time.

The other point stands as the review judged it: the empty-`$target` branch exits
0 on purpose. `exit 1` in a runbook people paste into an interactive shell would
close their terminal, and the message is right there on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J4qKCjj4CnJ1bHCYQP4JJ
