### PR TITLE
docs: state the conventions where a contributor will actually see them

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,7 @@
       supported Vitest range, the commit is marked `type!:` and carries a
       `BREAKING CHANGE:` footer
 
-See CONTRIBUTING.md.
+<!-- Rendered as a PR body, so this has to be an absolute URL: GitHub resolves
+     relative links in issue and PR bodies against the page, not the repo. -->
+
+See [CONTRIBUTING.md](https://github.com/akiomik/vitest-websocket-mock/blob/main/CONTRIBUTING.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- What changes, and why. -->
+
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]`, or this needs none
+- [ ] If this breaks the exported types, the matcher signatures, or the
+      supported Vitest range, the commit is marked `type!:` and carries a
+      `BREAKING CHANGE:` footer
+
+See CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Commits
+
+Commit messages follow [Conventional Commits 1.0.0][cc].
+
+A change that breaks the public API — the exported types, the matcher
+signatures, or the supported Vitest range — must be marked as one: `!` before
+the `:` in the subject, plus a `BREAKING CHANGE:` footer saying what breaks.
+Nothing verifies this. Whether a change is breaking is a judgement only the
+author can make, and it is the easiest rule here to miss, because nearly every
+commit is a routine dependency bump that never needs it.
+
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog][kac], and the project is versioned
+with [Semantic Versioning][semver].
+
+Write your entry under `## [Unreleased]` in the same pull request as the change.
+Releases do not write entries; they only move that section under a version
+heading. The project is on 0.x, where a breaking change takes a minor.
+
+## Releasing
+
+See [RELEASING.md](RELEASING.md).
+
+[cc]: https://www.conventionalcommits.org/en/v1.0.0/
+[kac]: https://keepachangelog.com/en/1.1.0/
+[semver]: https://semver.org/spec/v2.0.0.html

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,7 +102,6 @@ history follows that: 0.6.0 and 0.7.0 both carried breaking changes, and so did
 the public API, the supported Vitest range, or the shipped types, and a patch
 only for fixes that leave all of those alone.
 
-Mark the breaking commit per [Conventional Commits][cc]: `!` before the `:` and
-a `BREAKING CHANGE:` footer.
-
-[cc]: https://www.conventionalcommits.org/en/v1.0.0/
+How a breaking commit is marked is in [CONTRIBUTING.md](CONTRIBUTING.md), where
+the author of the change will see it. By the time you are here, the marking has
+either happened or it has not.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,5 +103,4 @@ the public API, the supported Vitest range, or the shipped types, and a patch
 only for fixes that leave all of those alone.
 
 How a breaking commit is marked is in [CONTRIBUTING.md](CONTRIBUTING.md), where
-the author of the change will see it. By the time you are here, the marking has
-either happened or it has not.
+the author of the change will see it.


### PR DESCRIPTION
The project follows three conventions and declared almost none of them where a
contributor would look:

| convention | stated where, before this PR |
| --- | --- |
| Conventional Commits 1.0.0 | nowhere — practice only |
| Keep a Changelog 1.1.0 | `CHANGELOG.md` header |
| Semantic Versioning 2.0.0 | `CHANGELOG.md` header |
| breaking commits need `!` + `BREAKING CHANGE:` | `RELEASING.md` only |
| when to update the changelog | nowhere |

The breaking-commit rule is the one that mattered, and its placement was wrong:
`RELEASING.md` is read while cutting a release, long after the breaking pull
request was authored. 0.8.0 shipped with a commit that missed the rule, and
nothing caught it — CI does not lint commit messages, and the history held no
prior breaking change to imitate.

## What this adds

**`CONTRIBUTING.md`** names all three conventions with links, says the changelog
entry belongs in the same PR as the change under `## [Unreleased]`, and points
at `RELEASING.md`. GitHub links to it when someone opens a pull request or an
issue, which is the moment it is needed.

**`.github/pull_request_template.md`** repeats just the two decisions an author
has to make — the changelog entry, and whether the change is breaking — in the
PR body while they are making them.

## Why no commitlint

Commit *format* has never failed here; the history is consistently well-formed,
and the 0.8.0 commit that missed the breaking marker would have passed a linter
untouched. What was missed is a judgement about whether a change breaks the
public API, which no tool can make for the author. A dependency, a config file,
a CI job and one more Dependabot target would buy enforcement of the part that
already works, so the cost lands on the wrong side.

Release automation such as release-please was considered and rejected for the
same reason plus a second one: it still depends on the author marking the
commit, and it would take over the hand-written changelog this project keeps
deliberately.

## Notes

Dependabot composes its own PR bodies and does not apply repository templates —
checked against `prometheus/prometheus`, which has a template, whose Dependabot
PR bodies contain none of it. The daily bump PRs here stay clean.

Neither file ships: `package.json` `files` is `dist` and `LICENSE`, and
`npm pack --dry-run` still reports the same five files.

## Review round

Both findings fixed.

**The template's pointer is now an absolute blob URL.** A relative link would
not have worked: GitHub resolves relative links in issue and PR bodies against
the page URL, not the repository. The file carries a comment saying so, because
shortening it back to a relative link is the obvious-looking cleanup. URL shape
confirmed against `blob/main/RELEASING.md` (200); `blob/main/CONTRIBUTING.md`
resolves once this merges.

**`RELEASING.md` no longer repeats the breaking-commit rule.** That was the
third copy, in the very file this PR argues is the wrong place for it. It now
covers only the version choice — a genuine release-time decision — and points at
CONTRIBUTING for the marking. The rule now appears in exactly two places, and
the CONTRIBUTING/template duplication is kept on purpose: one line, read at two
different moments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J4qKCjj4CnJ1bHCYQP4JJ
